### PR TITLE
Return proper dependency URIs in workspaceBuildTargets

### DIFF
--- a/server/src/main/java/org/jetbrains/maven/project/ProjectId.java
+++ b/server/src/main/java/org/jetbrains/maven/project/ProjectId.java
@@ -1,0 +1,10 @@
+package org.jetbrains.maven.project;
+
+import lombok.Value;
+
+@Value
+public class ProjectId {
+  private final String groupId;
+  private final String artifactId;
+  private final String version;
+}


### PR DESCRIPTION
* Added `MavenProjectWrapper::getModuleProjects` to first collect all internal dependencies which in turn will be searched for correct URIs in `MavenProjectWrapper::getDependencies`.
* Changed `MavenBSPServer::workspaceBuildTargets` accordingly.
* Tested on client side jumping to another module.